### PR TITLE
Fix Base.(:(==)) warning on 0.5

### DIFF
--- a/src/AutoHashEquals.jl
+++ b/src/AutoHashEquals.jl
@@ -31,9 +31,17 @@ function auto_equals(name, names)
         end
     end
 
-    quote
-        function Base.(:(==))(a::$(name), b::$(name)) 
-            $(expand(length(names)))
+    if VERSION < v"0.5-pre"
+        quote
+            function Base.(:(==))(a::$(name), b::$(name))
+                $(expand(length(names)))
+            end
+        end
+    else
+        quote
+            function Base.:(==)(a::$(name), b::$(name))
+                $(expand(length(names)))
+            end
         end
     end
 end


### PR DESCRIPTION
This was causing a lot of warnings on a lot of packages
