### PR TITLE
Allow struct syntax, add 0.6 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - osx
 julia:
   - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 
 # AutoHashEquals
 
-A macro to add == and hash() to composite types (ie type and immutable
+A macro to add == and hash() to composite types (ie struct and mutable struct
 blocks).
 
 For example:
 
 ```julia
-@auto_hash_equals type Foo
+@auto_hash_equals mutable struct Foo
     a::Int
     b
 end
@@ -22,7 +22,7 @@ end
 becomes
 
 ```julia
-type Foo
+mutable struct Foo
     a::Int
     b
 end
@@ -44,8 +44,8 @@ Where
 
 ## Background
 
-Julia has two composite types: *value* types, defined with `immutable`, and
-*record* types, defined with `type`.
+Julia has two composite types: *value* types, defined with `struct`, and
+*record* types, defined with `mutable struct`.
 
 Value types are intended for compact, immutable objects.  They are stored on
 the stack, passed by value, and the default hash and equality are based on the
@@ -69,7 +69,7 @@ This macro automates this common approach.
 
 ## Warnings
 
-If you use this macro for a mutable type, then the hash depends on the
+If you use this macro for a mutable types, then the hash depends on the
 contents of that type, so changing the contents changes the hash.  Such types
 should not be stored in a hash table (Dict) and then mutated, because the
 objects will be "lost" (as the hash table *assumes* that hash is constant).

--- a/src/AutoHashEquals.jl
+++ b/src/AutoHashEquals.jl
@@ -48,7 +48,7 @@ function unpack_name(node::Expr)
     if node.head == :macrocall
         unpack_name(node.args[2])
     else
-        i = node.head == :type ? 2 : 1   # skip mutable flag
+        i = node.head == :type || node.head == :struct ? 2 : 1   # skip mutable flag
         if length(node.args) >= i && isa(node.args[i], Symbol)
             node.args[i]
         elseif length(node.args) >= i && isa(node.args[i], Expr) && node.args[i].head in (:(<:), :(::))
@@ -64,7 +64,7 @@ end
 
 macro auto_hash_equals(typ)
 
-    @assert typ.head == :type
+    @assert typ.head == :type || typ.head == :struct
     name = unpack_name(typ)
 
     names = Vector{Symbol}()


### PR DESCRIPTION
There's also some deprecation warnings that can be fixed with the new syntax, but that breaks 0.5 and I'm not sure if you want to drop support for that yet or not.