### PR TITLE
Allow AutoHashEquals for signleton types

### DIFF
--- a/src/AutoHashEquals.jl
+++ b/src/AutoHashEquals.jl
@@ -76,7 +76,6 @@ macro auto_hash_equals(typ)
             # not a field
         end
     end
-    @assert length(names) > 0
 
     quote
         Base.@__doc__($(esc(typ)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,4 +92,11 @@ end
 end
 @test plain(@doc MyType) == "this is my data type\n"
 
+@auto_hash_equals struct J end
+@auto_hash_equals struct K end
+
+@test J() == J()
+@test hash(J()) == hash(J())
+@test hash(J()) != hash(K())
+
 println("ok")


### PR DESCRIPTION
I have singleton types (they control branching on algorithms), and I would like them to have stable hashes. Your package does the trick!