### PR TITLE
Allow combination with other macros

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,4 +92,18 @@ end
 end
 @test plain(@doc MyType) == "this is my data type\n"
 
+# Interactions with other struct-level macros
+
+@auto_hash_equals Base.@kwdef struct J
+    a = 1
+    b = []
+end
+@test J() == J() == J(b=[])
+@test J(a=1, b=[2]) == J(a=1, b=[2])
+
+@auto_hash_equals @auto_hash_equals struct H
+   x 
+end
+@test H([]) == H([])
+
 println("ok")


### PR DESCRIPTION
This is a super useful macro, but it's a shame it can't be used in conjunction with other struct-level macros, like `Base.@kwdef`.

This PR is an attempt to make that work :)

----

I first considered searching the un-expanded input expression for any `:struct` definition(s), but I think that's suboptimal, since in theory the inner macro may make some changes, and we should support those changes. So instead, this macro first expands the potential inner macro, and then searches the result to find the `Base.@doc` expression, which should be decorating the new struct definition, and uses that to do its processing.


I think this should work correctly, but probably could do with a bit more error checking to handle the case where the inner macro produces multiple structs with `Base.@doc`, or doesn't use `@doc`, etc.

Still, I figured it's better to push up my WIP than to just leave it to rot in private on my computer :)