### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,40 @@
+name: CI
+on:
+  push:
+    branches:
+      - master
+    tags: ['*']
+  pull_request:
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - "1.6"  # LTS
+          - "1"    # Latest Release
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+          - x86
+    steps:
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v3
+        with:
+          files: lcov.info


### PR DESCRIPTION
TODO:
- [ ] Remove Travis CI
- [ ] Change badges (Travis -> GItHub, Coveralls -> Codecov)

I have Codecov in here because the Julia Actions support for Coveralls seemed less mature and also seemed like it might require access to secrets, which I do not have on this repo. 

I only test on Linux because I don't expect there to be OS differences, but include `x86` because of how important the UInt alias is to hashing. I also bumped the minimum tested version to LTS. 

Closes #28 