### PR TITLE
Update `==` and `isequal` semantics to match NamedTuple's

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
           - '1.7'
           - '1.8'
           - '1.9'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.7'
           - '1.8'
+          - '1.8.2'
           - '1.9'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -7,4 +7,4 @@ version = "2.0.0"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
-julia = "1.6"
+julia = "1.7"

--- a/Project.toml
+++ b/Project.toml
@@ -7,4 +7,4 @@ version = "2.0.0"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
-julia = "1.7"
+julia = "1.8"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AutoHashEquals"
 uuid = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 authors = ["Neal Gafter <neal@gafter.com>", "andrew cooke <andrew@acooke.org>"]
-version = "1.0.0"
+version = "2.0.0"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ end
 
 You can specify that type arguments should be significant for the purposes of computing the hash function and checking equality by adding the keyword parameter `typearg=true`.  By default they are not significant.  You can specify the default (they are not significant) with `typearg=false`:
 
-```julia-repl
+```julia
 julia> @auto_hash_equals struct Box1{T}
            x::T
        end

--- a/README.md
+++ b/README.md
@@ -185,3 +185,32 @@ If `typearg=true`, then `e(t)` is used as the type seed, where `t` is the type o
 
 Note that the value of `typeseed` is expected to be a `UInt` value when `typearg=false` (or `typearg` is not specified),
 but a function that takes a type as its argument when `typearg=true`.
+
+## Compatibility mode
+
+In versions `v"1.0"` and earlier of `AutoHashEquals`, we produced a specialization of `Base.==`, implemented using `Base.isequal`.
+This was not correct.
+See https://docs.julialang.org/en/v1/base/base/#Base.isequal and https://docs.julialang.org/en/v1/base/math/#Base.:==.
+More correct would be to define `==` by using `==` on the members, and to define `isequal` by using `isequal` on the members.
+In version `v"2.0"` we provide a correct implementation, thanks to @ericphanson.
+
+To get the same behavior as `v"1.0"` of this package, in which `==` is implemented based on `isequal`,
+you can specify `compat1=true`.
+
+```julia
+@auto_hash_equals struct Box890{T}
+    x::T
+end
+@assert ismissing(Box890(missing) == Box890(missing))
+@assert isequal(Box890(missing), Box890(missing))
+@assert ismissing(Box890(missing) == Box890(1))
+@assert !isequal(Box890(missing), Box890(1))
+
+@auto_hash_equals compat1=true struct Box891{T}
+    x::T
+end
+@assert Box891(missing) == Box891(missing)
+@assert isequal(Box891(missing), Box891(missing))
+@assert Box891(missing) != Box891(1)
+@assert !isequal(Box891(missing), Box891(1))
+```

--- a/src/AutoHashEquals.jl
+++ b/src/AutoHashEquals.jl
@@ -19,6 +19,7 @@ Options:
 * `fields=a,b,c` the fields to use for hashing and equality. Default: all fields.
 * `typearg=true|false` whether or not to make type arguments significant. Default: `false`.
 * `typeseed=e` Use `e` (or `e(type)` if `typearg=true`) as the seed for hashing type arguments.
+* `compat1=true` To have `==` defined by using `isequal`.  Default: `false`.
 """
 macro auto_hash_equals(args...)
     kwargs = Dict{Symbol,Any}()

--- a/src/AutoHashEquals.jl
+++ b/src/AutoHashEquals.jl
@@ -9,7 +9,7 @@ include("impl.jl")
 """
     @auto_hash_equals [options] struct Foo ... end
 
-Generate `Base.hash` and `Base.==` methods for `Foo`.
+Generate `Base.hash`, `Base.isequal`, and `Base.==` methods for `Foo`.
 
 Options:
 

--- a/src/impl.jl
+++ b/src/impl.jl
@@ -323,45 +323,34 @@ function auto_hash_equals_impl(__source__, struct_decl, fields, cache::Bool, has
             # If no field comparisons are false, but one comparison missing, then we return missing.
             # Otherwise we return true.
             # (This matches the semantics of `==` for `Tuple`'s and `NamedTuple`'s.)
-
-            # Here we do some manual hygiene, since we will escape everything at the end
-            found_missing = gensym(:found_missing)
-            cmp = gensym(:cmp)
-            equalty_impl = quote
-                $found_missing = false
-            end
+            equalty_impl = :(found_missing = false)
             if cache
-                q = quote
-                    $cmp = a._cached_hash == b._cached_hash
-                    $cmp === false && return false
-                end
+                q = :(
+                    cmp = a._cached_hash == b._cached_hash;
+                    cmp === false && return false;
+                )
                 append!(equalty_impl.args, q.args)
             end
             for f in fields
-                q = quote
-                    $cmp = $eq($getfield(a, $(QuoteNode(f))), $getfield(b, $(QuoteNode(f))))
-                    $cmp === false && return false
-                    if $ismissing($cmp)
-                        $found_missing = true
-                    end
-                end
+                q = :(
+                    cmp = $isequal($getfield(a, $(QuoteNode(f))), $getfield(b, $(QuoteNode(f))));
+                    cmp === false && return false;
+                    $ismissing(cmp) && (found_missing = true);
+                )
                 append!(equalty_impl.args, q.args)
             end
-            q = quote
-                $found_missing && return missing
-                return true
-            end
+            q = :(return $ifelse(found_missing, missing, true))
             append!(equalty_impl.args,q.args)
         end
 
         fn_name = Symbol(eq)
         if isnothing(where_list) || !typearg
-            push!(result.args, esc(:(function (Base).$fn_name(a::$type_name, b::$type_name)
+            push!(result.args, esc(:(function ($Base).$fn_name(a::$type_name, b::$type_name)
                 $equalty_impl
             end)))
         else
             # If requested, require the type arguments be the same for two instances to be equal
-            push!(result.args, esc(:(function (Base).$fn_name(a::$full_type_name, b::$full_type_name) where {$(where_list...)}
+            push!(result.args, esc(:(function ($Base).$fn_name(a::$full_type_name, b::$full_type_name) where {$(where_list...)}
                 $equalty_impl
             end)))
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -249,23 +249,31 @@ end
             @test hash(T135(1, :x)) == hash(serialize_and_deserialize(T135(1, :x)))
         end
 
-        @testset "contained NaN values compare equal" begin
+        @testset "contained NaN values compare isequal (but not ==)" begin
             @auto_hash_equals_cached struct T140
                 x
             end
             nan = 0.0 / 0.0
             @test nan != nan
-            @test T140(nan) == T140(nan)
+            @test isequal(T140(nan), T140(nan))
+            @test T140(nan) != T140(nan)
+
         end
 
-        @testset "ensure circular data structures, produced by hook or by crook, do not blow the stack" begin
+        @testset "circular data structures behavior" begin
             @auto_hash_equals_cached struct T145
                 a::Array{Any,1}
             end
             t::T145 = T145(Any[1])
             t.a[1] = t
+            # hash does not stack overflow thanks to the cache
             @test hash(t) != 0
-            @test t == t
+            # `==` overflows
+            @test_throws StackOverflowError t == t
+            # isequal does not
+            @test isequal(t, t)
+            @test !isequal(t, T145(Any[]))
+            # Check printing
             @test "$t" == "$(T145)(Any[$(T145)(#= circular reference @-2 =#)])"
         end
 
@@ -501,13 +509,14 @@ end
             @test hash(T313(1, :x)) == hash(serialize_and_deserialize(T313(1, :x)))
         end
 
-        @testset "contained NaN values compare equal" begin
+        @testset "contained NaN values compare isequal (but not ==)" begin
             @auto_hash_equals struct T330
                 x
             end
             nan = 0.0 / 0.0
             @test nan != nan
-            @test T330(nan) == T330(nan)
+            @test isequal(T330(nan), T330(nan))
+            @test T330(nan) != T330(nan)
         end
 
         @testset "give no error if the struct contains internal constructors" begin
@@ -633,6 +642,43 @@ end
             end
             @test Box629{Int}(1) == Box629{Any}(1)
             @test hash(Box629{Int}(1)) == hash(Box629{Any}(1))
+        end
+
+        @testset "== propogates missing, but `isequal` does not" begin
+            # Fixed by https://github.com/JuliaServices/AutoHashEquals.jl/issues/18
+            @auto_hash_equals struct Box18{T}
+                x::T
+            end
+            ret = Box18(missing) == Box18(missing)
+            @test ret === missing
+            ret = Box18(missing) == Box18(1)
+            @test ret === missing
+            @test isequal(Box18(missing), Box18(missing))
+            @test !isequal(Box18(missing), Box18(1))
+
+            @auto_hash_equals struct Two18{T1, T2}
+                x::T1
+                y::T2
+            end
+            ret = Two18(1, missing) == Two18(1, 2)
+            @test ret === missing
+
+            ret = Two18(5, missing) == Two18(1, 2)
+            @test ret === false
+
+            ret = Two18(missing, 2) == Two18(1, 2)
+            @test ret === missing
+
+            ret = Two18(missing, 5) == Two18(1, 2)
+            @test ret === false
+
+            @auto_hash_equals mutable struct MutBox18{T}
+                x::T
+            end
+            b = MutBox18(missing)
+            ret = b == b
+            @test ret === missing
+            @test isequal(b, b)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,9 +20,7 @@ function serialize_and_deserialize(x)
 end
 
 macro noop(x)
-    esc(quote
-       Base.@__doc__$(x)
-    end)
+    esc(x)
 end
 
 macro _const(x)
@@ -885,6 +883,24 @@ abstract type B{T} end
             ret = b == b
             @test ret === missing
             @test isequal(b, b)
+        end
+
+        @testset "test the compat1 flag" begin
+            @auto_hash_equals struct Box890{T}
+                x::T
+            end
+            @test ismissing(Box890(missing) == Box890(missing))
+            @test isequal(Box890(missing), Box890(missing))
+            @test ismissing(Box890(missing) == Box890(1))
+            @test !isequal(Box890(missing), Box890(1))
+
+            @auto_hash_equals compat1=true struct Box891{T}
+                x::T
+            end
+            @test Box891(missing) == Box891(missing)
+            @test isequal(Box891(missing), Box891(missing))
+            @test Box891(missing) != Box891(1)
+            @test !isequal(Box891(missing), Box891(1))
         end
     end
 end


### PR DESCRIPTION
closes https://github.com/JuliaServices/AutoHashEquals.jl/issues/18

I went for the breaking change, since that is easier to implement and less confusing for users to have a setting that changes the semantics in subtle ways.