### PR TITLE
Add tests for hash stability between Julia versions.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -634,6 +634,101 @@ end
             @test Box629{Int}(1) == Box629{Any}(1)
             @test hash(Box629{Int}(1)) == hash(Box629{Any}(1))
         end
+
+        @testset "Check that by default the hash function is stable after 1.7" begin
+            # The value of `Base.hash(:x, UInt(0))` changed in 1.7, so it was already
+            # unstable between 1.6 and 1.7.  Here we just add tests so that future
+            # changes to the hash function will be observed.
+
+            @auto_hash_equals struct Box1
+                x
+            end
+
+            if VERSION < v"1.7"
+                @test 0x67d66c8ebce604c4 === hash(Box1(1))
+                @test 0x57ce10fa6d65774c === hash(Box1(:x))
+                @test 0x7951851906420162 === hash(Box1("a"))
+                @test 0x6a46c6ef41c6b97d === hash(Box1(1), UInt(1))
+                @test 0x0ef668a2dd4500a0 === hash(Box1(:x), UInt(1))
+                @test 0x7398684da66deba5 === hash(Box1("a"), UInt(1))
+            else
+                @test 0x05014b35fc91d289 === hash(Box1(1))
+                @test 0x91d7652c7a24efb3 === hash(Box1(:x))
+                @test 0x1d9ac96f957cc50a === hash(Box1("a"))
+                @test 0x6e0378444e962be8 === hash(Box1(1), UInt(1))
+                @test 0xa31a1cd3c72d944c === hash(Box1(:x), UInt(1))
+                @test 0xe563b59c847e3d2f === hash(Box1("a"), UInt(1))
+            end
+
+            @auto_hash_equals struct Box2{T}
+                x::T
+            end
+
+            if VERSION < v"1.7"
+                @test 0x97e8e85cce6400e5 === hash(Box2(1))
+                @test 0x97e8e85cce6400e5 === hash(Box2{Any}(1))
+                @test 0x95c1c5ce8a9d4310 === hash(Box2(:x))
+                @test 0x9424a3ad9ea0312c === hash(Box2("a"))
+                @test 0xd7caed9a4e280b13 === hash(Box2(1), UInt(1))
+                @test 0xd7caed9a4e280b13 === hash(Box2{Any}(1), UInt(1))
+                @test 0x3c6236446852acfb === hash(Box2(:x), UInt(1))
+                @test 0x08aaed0ddd68f482 === hash(Box2("a"), UInt(1))
+            else
+                @test 0xfddfe30b106aa2f0 === hash(Box2(1))
+                @test 0xfddfe30b106aa2f0 === hash(Box2{Any}(1))
+                @test 0xb9abdfa5883b32bb === hash(Box2(:x))
+                @test 0x6c49b14653a071c6 === hash(Box2("a"))
+                @test 0x451b0ebf9ee0f99c === hash(Box2(1), UInt(1))
+                @test 0x451b0ebf9ee0f99c === hash(Box2{Any}(1), UInt(1))
+                @test 0x175e9079609f34c5 === hash(Box2(:x), UInt(1))
+                @test 0x77cf64ab93060d1e === hash(Box2("a"), UInt(1))
+            end
+
+            @auto_hash_equals struct Box3
+                x
+            end
+
+            if VERSION < v"1.7"
+                @test 0xa28c5530534e00ff === hash(Box3(1))
+                @test 0xbd098dc8d84b2b3c === hash(Box3(:x))
+                @test 0x306232d62b351152 === hash(Box3("a"))
+                @test 0xd4f16da2b818329f === hash(Box3(1), UInt(1))
+                @test 0xbc02b85a84d59f22 === hash(Box3(:x), UInt(1))
+                @test 0xf3298984f3d3f10e === hash(Box3("a"), UInt(1))
+            else
+                @test 0x6c8a62ecebe7d0ce === hash(Box3(1))
+                @test 0xb3dc0f774c8dbf65 === hash(Box3(:x))
+                @test 0x18c77bdc2543b944 === hash(Box3("a"))
+                @test 0x1fe5e7cdd29edab1 === hash(Box3(1), UInt(1))
+                @test 0x55e8647bf53d5ecd === hash(Box3(:x), UInt(1))
+                @test 0xf556f204c1f1bc53 === hash(Box3("a"), UInt(1))
+            end
+
+            @auto_hash_equals struct Box4{T}
+                x::T
+            end
+
+            if VERSION < v"1.7"
+                @test 0xa0164c66e926af40 === hash(Box4(1))
+                @test 0xa0164c66e926af40 === hash(Box4{Any}(1))
+                @test 0xcb0ce1b2da05840b === hash(Box4(:x))
+                @test 0xc10479084e27e5db === hash(Box4("a"))
+                @test 0xdbc4ab0260836c4a === hash(Box4(1), UInt(1))
+                @test 0xdbc4ab0260836c4a === hash(Box4{Any}(1), UInt(1))
+                @test 0x485f0ce7fd57b390 === hash(Box4(:x), UInt(1))
+                @test 0xaff3b9595e40223d === hash(Box4("a"), UInt(1))
+            else
+                @test 0x98dc0cd9a86cbdee === hash(Box4(1))
+                @test 0x98dc0cd9a86cbdee === hash(Box4{Any}(1))
+                @test 0x3dbd99c859966133 === hash(Box4(:x))
+                @test 0xa7d6e8579ef5a8cd === hash(Box4("a"))
+                @test 0x44ac08ef000cb686 === hash(Box4(1), UInt(1))
+                @test 0x44ac08ef000cb686 === hash(Box4{Any}(1), UInt(1))
+                @test 0xc7dc8347992b452d === hash(Box4(:x), UInt(1))
+                @test 0x3dcb6b6168a2c18d === hash(Box4("a"), UInt(1))
+            end
+
+        end
     end
 end
 


### PR DESCRIPTION
I'd like to have this test in place before we make any more changes to computed hash codes.  Thus I'm making a separate PR.