### PR TITLE
Add compat version of the macro (needed for rai)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@
 
 The AutoHashEquals.jl package is licensed under the MIT "Expat" License:
 
-Copyright (c) 2015-2023: andrew cooke, RelationalAI, Inc, and contributors.
+Copyright (c) 2015-2023: Neal Gafter, Andrew Cooke, RelationalAI, Inc, and contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AutoHashEquals"
 uuid = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 authors = ["Neal Gafter <neal@gafter.com>", "andrew cooke <andrew@acooke.org>"]
-version = "2.0.0"
+version = "2.1.0"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/README.md
+++ b/README.md
@@ -214,3 +214,10 @@ end
 @assert Box891(missing) != Box891(1)
 @assert !isequal(Box891(missing), Box891(1))
 ```
+
+If you need compatibility mode allways and don't want to have to specify the mode on each invocation,
+you can instead import the compatibility version of the macro, which defaults to `compat1=true':
+
+```julia
+using AutoHashEquals.Compat
+```

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ end
 @assert !isequal(Box891(missing), Box891(1))
 ```
 
-If you need compatibility mode allways and don't want to have to specify the mode on each invocation,
+If you need compatibility mode always and don't want to have to specify the mode on each invocation,
 you can instead import the compatibility version of the macro, which defaults to `compat1=true':
 
 ```julia

--- a/src/AutoHashEquals.jl
+++ b/src/AutoHashEquals.jl
@@ -6,6 +6,7 @@ export @auto_hash_equals
 
 include("type_seed.jl")
 include("impl.jl")
+include("compat.jl")
 
 """
     @auto_hash_equals [options] struct Foo ... end

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,0 +1,25 @@
+module Compat
+
+using AutoHashEquals: AutoHashEquals
+
+export @auto_hash_equals
+
+"""
+    @auto_hash_equals [options] struct Foo ... end
+
+Generate `Base.hash`, `Base.isequal`, and `Base.==` methods for `Foo`.
+
+Options:
+
+* `cache=true|false` whether or not to generate an extra cache field to store the precomputed hash value. Default: `false`.
+* `hashfn=myhash` the hash function to use. Default: `Base.hash`.
+* `fields=a,b,c` the fields to use for hashing and equality. Default: all fields.
+* `typearg=true|false` whether or not to make type arguments significant. Default: `false`.
+* `typeseed=e` Use `e` (or `e(type)` if `typearg=true`) as the seed for hashing type arguments.
+* `compat1=true` To have `==` defined by using `isequal`.  Default: `true`.
+"""
+macro auto_hash_equals(args...)
+    esc(:($AutoHashEquals.@auto_hash_equals(compat1=true, $(args...))))
+end
+
+end

--- a/src/impl.jl
+++ b/src/impl.jl
@@ -234,7 +234,7 @@ function auto_hash_equals_impl(__source__, struct_decl, fields, cache::Bool, has
             if typearg
                 :($type_seed($full_type_name))
             else
-                Base.hash(type_name)
+                :($hashfn($(QuoteNode(type_name))))
             end
         else
             if typearg
@@ -275,11 +275,11 @@ function auto_hash_equals_impl(__source__, struct_decl, fields, cache::Bool, has
                 if typearg
                     :($type_seed($full_type_name, h))
                 else
-                    :($(Base.hash)($(QuoteNode(type_name)), h))
+                    :($hashfn($(QuoteNode(type_name)), h))
                 end
             else
                 if typearg
-                    :(h + UInt($typeseed($full_type_name)))
+                    :(UInt($typeseed($full_type_name, h)))
                 else
                     :(h + UInt($typeseed))
                 end
@@ -360,9 +360,6 @@ function auto_hash_equals_impl(__source__, struct_decl, fields, cache::Bool, has
                 equality_impl = :(a === b || $equality_impl)
             end
         else
-            # Julia library defines `isequal` in terms of `==`.
-            compat1 && continue
-
             # Here we have a more complicated implementation in order to handle missings correctly.
             # If any field comparison is false, we return false (even if some return missing).
             # If no field comparisons are false, but one comparison missing, then we return missing.

--- a/test/compat.jl
+++ b/test/compat.jl
@@ -1,0 +1,16 @@
+module compat
+
+using AutoHashEquals.Compat: @auto_hash_equals
+using Test
+
+@testset "test the compat macro" begin
+    @auto_hash_equals struct Box851{T}
+        x::T
+    end
+    @test Box851(missing) == Box851(missing)
+    @test isequal(Box851(missing), Box851(missing))
+    @test Box851(missing) != Box851(1)
+    @test !isequal(Box851(missing), Box851(1))
+end
+
+end


### PR DESCRIPTION
Version 2.1.0 adds a version of the macro for clients that need strict compatibility with version 1.0, in which `==` is defined in terms of `==` instead of `isequal`.