### PR TITLE
get rid of Pkg dependency

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,9 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.8'
-          - '1.8.2'
           - '1.9'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,7 @@
 name = "AutoHashEquals"
 uuid = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 authors = ["Neal Gafter <neal@gafter.com>", "andrew cooke <andrew@acooke.org>"]
-version = "2.1.0"
-
-[deps]
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "2.2.0"
 
 [compat]
-julia = "1.8"
+julia = "1.9"

--- a/src/impl.jl
+++ b/src/impl.jl
@@ -1,12 +1,4 @@
-using Pkg
-
 const is_expr = Base.Meta.isexpr
-
-function pkgversion(m::Module)
-    pkgdir = dirname(string(first(methods(m.eval)).file))
-    toml = Pkg.TOML.parsefile(joinpath(pkgdir, "..", "Project.toml"))
-    VersionNumber(toml["version"])
-end
 
 function if_has_package(
     action::Function,
@@ -17,7 +9,7 @@ function if_has_package(
     pkgid = Base.PkgId(uuid, name)
     if Base.root_module_exists(pkgid)
         pkg = Base.root_module(pkgid)
-        if pkgversion(pkg) >= version
+        if Base.pkgversion(pkg) >= version
             return action(pkg)
         end
     end


### PR DESCRIPTION
we can use `Base.pkgversion` if we restrict ourselves to julia 1.9+
